### PR TITLE
Add .clang-format config, provide to super-linter, and apply formatting to codebase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,168 @@
+# From https://github.com/pytorch/pytorch/blob/379bbef23c144aba4ae6e01d9e1247c4a44b3e74/.clang-format
+# License:
+# From PyTorch:
+# 
+# Copyright (c) 2016-     Facebook, Inc            (Adam Paszke)
+# Copyright (c) 2014-     Facebook, Inc            (Soumith Chintala)
+# Copyright (c) 2011-2014 Idiap Research Institute (Ronan Collobert)
+# Copyright (c) 2012-2014 Deepmind Technologies    (Koray Kavukcuoglu)
+# Copyright (c) 2011-2012 NEC Laboratories America (Koray Kavukcuoglu)
+# Copyright (c) 2011-2013 NYU                      (Clement Farabet)
+# Copyright (c) 2006-2010 NEC Laboratories America (Ronan Collobert, Leon Bottou, Iain Melvin, Jason Weston)
+# Copyright (c) 2006      Idiap Research Institute (Samy Bengio)
+# Copyright (c) 2001-2004 Idiap Research Institute (Ronan Collobert, Samy Bengio, Johnny Mariethoz)
+# 
+# From Caffe2:
+# 
+# Copyright (c) 2016-present, Facebook Inc. All rights reserved.
+# 
+# All contributions by Facebook:
+# Copyright (c) 2016 Facebook Inc.
+# 
+# All contributions by Google:
+# Copyright (c) 2015 Google Inc.
+# All rights reserved.
+# 
+# All contributions by Yangqing Jia:
+# Copyright (c) 2015 Yangqing Jia
+# All rights reserved.
+# 
+# All contributions by Kakao Brain:
+# Copyright 2019-2020 Kakao Brain
+# 
+# All contributions by Cruise LLC:
+# Copyright (c) 2022 Cruise LLC.
+# All rights reserved.
+# 
+# All contributions by Tri Dao:
+# Copyright (c) 2024 Tri Dao.
+# All rights reserved.
+# 
+# All contributions by Arm:
+# Copyright (c) 2021, 2023-2024 Arm Limited and/or its affiliates
+# 
+# All contributions from Caffe:
+# Copyright(c) 2013, 2014, 2015, the respective contributors
+# All rights reserved.
+# 
+# All other contributions:
+# Copyright(c) 2015, 2016 the respective contributors
+# All rights reserved.
+# 
+# Caffe2 uses a copyright model similar to Caffe: each contributor holds
+# copyright over their contributions to Caffe2. The project versioning records
+# all such contribution and copyright details. If a contributor wants to further
+# mark their specific copyright on a particular contribution, they should
+# indicate their copyright solely in the commit message of the change when it is
+# committed.
+# 
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 
+# 3. Neither the names of Facebook, Deepmind Technologies, NYU, NEC Laboratories America
+#    and IDIAP Research Institute nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without
+#    specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+---
+AccessModifierOffset: -1
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   false
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit:     80
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+IncludeCategories:
+  - Regex:           '^<.*\.h(pp)?>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 2000000
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        c++17
+TabWidth:        8 
+UseTab:          Never
+---

--- a/.github/config/lint/.clang-format
+++ b/.github/config/lint/.clang-format
@@ -1,0 +1,1 @@
+../../../.clang-format

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -25,7 +25,7 @@ jobs:
           # within `super-linter`
           fetch-depth: 0
       - name: Super-linter
-        uses: super-linter/super-linter@v7.2.1 # x-release-please-version
+        uses: super-linter/super-linter@v7.3.0 # x-release-please-version
         env:
           LINTER_RULES_PATH: .github/config/lint
           # To report GitHub Actions status checks

--- a/gloo/allreduce_bcube.h
+++ b/gloo/allreduce_bcube.h
@@ -217,8 +217,11 @@ class Group {
    * @count The total number of elements to be processed by this node
    * @return The number of elements to be processed by this group
    */
-  static int
-  computeNumElems(int step, const Node& firstNode, int peers, int count) {
+  static int computeNumElems(
+      int step,
+      const Node& firstNode,
+      int peers,
+      int count) {
     int groupCount =
         (0 == step) ? count : firstNode.getNumElemsPerStep(step - 1);
     return std::max(groupCount, peers);
@@ -229,8 +232,11 @@ class Group {
    *   group
    * @return List of ranks of nodes in the group
    */
-  std::vector<int>
-  getNodeRanks(int firstNodeRank, int peerDistance, int base, int nodes) const {
+  std::vector<int> getNodeRanks(
+      int firstNodeRank,
+      int peerDistance,
+      int base,
+      int nodes) const {
     std::vector<int> groupPeers;
     for (int i = 0; i < base; ++i) {
       int peerRank = firstNodeRank + i * peerDistance;

--- a/gloo/alltoallv.h
+++ b/gloo/alltoallv.h
@@ -78,8 +78,10 @@ class AlltoallvOptions {
       size_t elementSize);
 
   // Untemplated implementation of setInput on opaque pointer.
-  void
-  setInput(void* ptr, std::vector<int64_t> elementsPerRank, size_t elementSize);
+  void setInput(
+      void* ptr,
+      std::vector<int64_t> elementsPerRank,
+      size_t elementSize);
 
   // Untemplated implementation of setOutput on unbound buffer.
   void setOutput(

--- a/gloo/common/string.h
+++ b/gloo/common/string.h
@@ -28,8 +28,10 @@ inline void MakeStringInternal(
 }
 
 template <typename T, typename... Args>
-inline void
-MakeStringInternal(std::stringstream& ss, const T& t, const Args&... args) {
+inline void MakeStringInternal(
+    std::stringstream& ss,
+    const T& t,
+    const Args&... args) {
   MakeStringInternal(ss, t);
   MakeStringInternal(ss, args...);
 }

--- a/gloo/cuda_allreduce_bcube.h
+++ b/gloo/cuda_allreduce_bcube.h
@@ -389,16 +389,22 @@ class Group {
    * @count The total number of elements to be processed by this node
    * @return The number of elements to be processed by this group
    */
-  static int
-  computeNumElems(int step, const Node& firstNode, int peers, int count);
+  static int computeNumElems(
+      int step,
+      const Node& firstNode,
+      int peers,
+      int count);
   /**
    * Determines all the nodes in a group in a particular step
    * @param peerDistance This is the distance between rank of each peer in the
    *   group
    * @return List of ranks of nodes in the group
    */
-  std::vector<int>
-  getNodeRanks(int firstNodeRank, int peerDistance, int base, int nodes) const;
+  std::vector<int> getNodeRanks(
+      int firstNodeRank,
+      int peerDistance,
+      int base,
+      int nodes) const;
 };
 
 } // namespace bcube

--- a/gloo/math.h
+++ b/gloo/math.h
@@ -98,23 +98,35 @@ inline uint32_t log2ceil(uint32_t value) {
 
 template <>
 void sum<float16>(void* c, const void* a, const void* b, size_t n);
-extern template void
-sum<float16>(void* c, const void* a, const void* b, size_t n);
+extern template void sum<float16>(
+    void* c,
+    const void* a,
+    const void* b,
+    size_t n);
 
 template <>
 void product<float16>(void* c, const void* a, const void* b, size_t n);
-extern template void
-product<float16>(void* c, const void* a, const void* b, size_t n);
+extern template void product<float16>(
+    void* c,
+    const void* a,
+    const void* b,
+    size_t n);
 
 template <>
 void max<float16>(void* c, const void* a, const void* b, size_t n);
-extern template void
-max<float16>(void* c, const void* a, const void* b, size_t n);
+extern template void max<float16>(
+    void* c,
+    const void* a,
+    const void* b,
+    size_t n);
 
 template <>
 void min<float16>(void* c, const void* a, const void* b, size_t n);
-extern template void
-min<float16>(void* c, const void* a, const void* b, size_t n);
+extern template void min<float16>(
+    void* c,
+    const void* a,
+    const void* b,
+    size_t n);
 
 #endif
 

--- a/gloo/test/base_test.h
+++ b/gloo/test/base_test.h
@@ -287,8 +287,10 @@ class Fixture<float16> {
     }
   }
 
-  void
-  checkBroadcastResult(Fixture<float16>& fixture, int root, int rootPointer) {
+  void checkBroadcastResult(
+      Fixture<float16>& fixture,
+      int root,
+      int rootPointer) {
     // Expected is set to the expected value at ptr[0]
     const auto expected = root * fixture.srcs.size() + rootPointer;
     // Stride is difference between values at subsequent indices
@@ -398,8 +400,10 @@ class Fixture<float> {
     }
   }
 
-  void
-  checkBroadcastResult(Fixture<float>& fixture, int root, int rootPointer) {
+  void checkBroadcastResult(
+      Fixture<float>& fixture,
+      int root,
+      int rootPointer) {
     // Expected is set to the expected value at ptr[0]
     const auto expected = root * fixture.srcs.size() + rootPointer;
     // Stride is difference between values at subsequent indices

--- a/gloo/transport/ibverbs/pair.cc
+++ b/gloo/transport/ibverbs/pair.cc
@@ -301,8 +301,10 @@ void Pair::postReceive() {
   }
 }
 
-std::unique_ptr<::gloo::transport::Buffer>
-Pair::createSendBuffer(int slot, void* ptr, size_t size) {
+std::unique_ptr<::gloo::transport::Buffer> Pair::createSendBuffer(
+    int slot,
+    void* ptr,
+    size_t size) {
   std::unique_lock<std::mutex> lock(m_);
   GLOO_ENFORCE_EQ(sendCompletionHandlers_.count(slot), 0);
   auto buffer = new Buffer(this, slot, ptr, size);
@@ -313,8 +315,10 @@ Pair::createSendBuffer(int slot, void* ptr, size_t size) {
   return std::unique_ptr<::gloo::transport::Buffer>(buffer);
 }
 
-std::unique_ptr<::gloo::transport::Buffer>
-Pair::createRecvBuffer(int slot, void* ptr, size_t size) {
+std::unique_ptr<::gloo::transport::Buffer> Pair::createRecvBuffer(
+    int slot,
+    void* ptr,
+    size_t size) {
   std::unique_lock<std::mutex> lock(m_);
   GLOO_ENFORCE_EQ(recvCompletionHandlers_.count(slot), 0);
   auto buffer = new Buffer(this, slot, ptr, size);

--- a/gloo/transport/ibverbs/pair.h
+++ b/gloo/transport/ibverbs/pair.h
@@ -75,11 +75,15 @@ class Pair : public ::gloo::transport::Pair {
 
   virtual void setSync(bool enable, bool busyPoll) override;
 
-  virtual std::unique_ptr<::gloo::transport::Buffer>
-  createSendBuffer(int slot, void* ptr, size_t size) override;
+  virtual std::unique_ptr<::gloo::transport::Buffer> createSendBuffer(
+      int slot,
+      void* ptr,
+      size_t size) override;
 
-  virtual std::unique_ptr<::gloo::transport::Buffer>
-  createRecvBuffer(int slot, void* ptr, size_t size) override;
+  virtual std::unique_ptr<::gloo::transport::Buffer> createRecvBuffer(
+      int slot,
+      void* ptr,
+      size_t size) override;
 
   virtual bool isConnected() override;
 

--- a/gloo/transport/pair.h
+++ b/gloo/transport/pair.h
@@ -30,11 +30,15 @@ class Pair {
 
   virtual void setSync(bool enable, bool busyPoll) = 0;
 
-  virtual std::unique_ptr<Buffer>
-  createSendBuffer(int slot, void* ptr, size_t size) = 0;
+  virtual std::unique_ptr<Buffer> createSendBuffer(
+      int slot,
+      void* ptr,
+      size_t size) = 0;
 
-  virtual std::unique_ptr<Buffer>
-  createRecvBuffer(int slot, void* ptr, size_t size) = 0;
+  virtual std::unique_ptr<Buffer> createRecvBuffer(
+      int slot,
+      void* ptr,
+      size_t size) = 0;
 
   virtual bool isConnected() = 0;
 

--- a/gloo/transport/tcp/pair.cc
+++ b/gloo/transport/tcp/pair.cc
@@ -392,8 +392,10 @@ void Pair::writeComplete(
 // buffer this message is intended for has not yet been registered (this can
 // only be the case for unbound buffers).
 //
-ssize_t
-Pair::prepareRead(Op& op, NonOwningPtr<UnboundBuffer>& buf, struct iovec& iov) {
+ssize_t Pair::prepareRead(
+    Op& op,
+    NonOwningPtr<UnboundBuffer>& buf,
+    struct iovec& iov) {
   iov.iov_base = nullptr;
   iov.iov_len = 0;
 
@@ -875,14 +877,18 @@ void Pair::recv() {
   }
 }
 
-std::unique_ptr<::gloo::transport::Buffer>
-Pair::createSendBuffer(int slot, void* ptr, size_t size) {
+std::unique_ptr<::gloo::transport::Buffer> Pair::createSendBuffer(
+    int slot,
+    void* ptr,
+    size_t size) {
   auto buffer = new Buffer(this, slot, ptr, size);
   return std::unique_ptr<::gloo::transport::Buffer>(buffer);
 }
 
-std::unique_ptr<::gloo::transport::Buffer>
-Pair::createRecvBuffer(int slot, void* ptr, size_t size) {
+std::unique_ptr<::gloo::transport::Buffer> Pair::createRecvBuffer(
+    int slot,
+    void* ptr,
+    size_t size) {
   auto buffer = new Buffer(this, slot, ptr, size);
   registerBuffer(buffer);
   return std::unique_ptr<::gloo::transport::Buffer>(buffer);

--- a/gloo/transport/tcp/pair.h
+++ b/gloo/transport/tcp/pair.h
@@ -111,11 +111,15 @@ class Pair : public ::gloo::transport::Pair, public Handler {
 
   virtual void setSync(bool sync, bool busyPoll) override;
 
-  virtual std::unique_ptr<::gloo::transport::Buffer>
-  createSendBuffer(int slot, void* ptr, size_t size) override;
+  virtual std::unique_ptr<::gloo::transport::Buffer> createSendBuffer(
+      int slot,
+      void* ptr,
+      size_t size) override;
 
-  virtual std::unique_ptr<::gloo::transport::Buffer>
-  createRecvBuffer(int slot, void* ptr, size_t size) override;
+  virtual std::unique_ptr<::gloo::transport::Buffer> createRecvBuffer(
+      int slot,
+      void* ptr,
+      size_t size) override;
 
   // Send from the specified buffer to remote side of pair.
   virtual void send(
@@ -252,8 +256,10 @@ class Pair : public ::gloo::transport::Pair, public Handler {
       const Op::Opcode& opcode) const;
 
   // Helper function for the `read` function below.
-  ssize_t
-  prepareRead(Op& op, NonOwningPtr<UnboundBuffer>& buf, struct iovec& iov);
+  ssize_t prepareRead(
+      Op& op,
+      NonOwningPtr<UnboundBuffer>& buf,
+      struct iovec& iov);
 
   // Read operation from socket into member variable (see `rx_`).
   //
@@ -285,8 +291,10 @@ class Pair : public ::gloo::transport::Pair, public Handler {
   virtual void changeState(state nextState) noexcept;
 
   template <typename pred_t>
-  void
-  waitUntil(pred_t pred, std::unique_lock<std::mutex>& lock, bool useTimeout) {
+  void waitUntil(
+      pred_t pred,
+      std::unique_lock<std::mutex>& lock,
+      bool useTimeout) {
     auto timeoutSet = timeout_ != kNoTimeout;
     if (useTimeout && timeoutSet) {
       // Use a longer timeout when waiting for initial connect

--- a/gloo/transport/uv/libuv.h
+++ b/gloo/transport/uv/libuv.h
@@ -554,11 +554,15 @@ class TCP final : public Handle<TCP, uv_tcp_t> {
 
   static void uv__connection_cb(uv_stream_t* server, int status);
 
-  static void
-  uv__alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);
+  static void uv__alloc_cb(
+      uv_handle_t* handle,
+      size_t suggested_size,
+      uv_buf_t* buf);
 
-  static void
-  uv__read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf);
+  static void uv__read_cb(
+      uv_stream_t* stream,
+      ssize_t nread,
+      const uv_buf_t* buf);
 
   static void uv__write_cb(uv_write_t* req, int status) {}
 

--- a/gloo/transport/uv/pair.h
+++ b/gloo/transport/uv/pair.h
@@ -111,13 +111,17 @@ class Pair : public ::gloo::transport::Pair {
     abort();
   }
 
-  virtual std::unique_ptr<::gloo::transport::Buffer>
-  createSendBuffer(int slot, void* ptr, size_t size) override {
+  virtual std::unique_ptr<::gloo::transport::Buffer> createSendBuffer(
+      int slot,
+      void* ptr,
+      size_t size) override {
     abort();
   }
 
-  virtual std::unique_ptr<::gloo::transport::Buffer>
-  createRecvBuffer(int slot, void* ptr, size_t size) override {
+  virtual std::unique_ptr<::gloo::transport::Buffer> createRecvBuffer(
+      int slot,
+      void* ptr,
+      size_t size) override {
     abort();
   }
 


### PR DESCRIPTION
55b6bf777b68a9c36b7034ca615411cb8d0cab15 applied clang-format to the codebase, but did not add the configuration file used. This change adds the configuration file, `.clang-format`, and applies clang-format to the codebase. The configuration file is imported from [PyTorch](https://github.com/pytorch/pytorch), with attribution in comments at the beginning of the file.

The config file used seems to line up well with the one used for 55b6bf777b68a9c36b7034ca615411cb8d0cab15, as the diff generated is relatively small. Having the config available will enable contributions going forward to use consistent formatting and avoid having to apply it across the whole codebase again.

To further this aim, I have linked the `.clang-format` into `.github/config/lint`, to enable the `lint` job in CI to utilise it for formatting checking. Additionally, I have updated the version of `super-linter` used in this job to a newer one, as this provides a much newer version of `clang-format`.

I have verified the super-linter job locally, using [act](https://github.com/nektos/act), and have confirmed it seems to be working fine. For this reason, I suggest that we can re-enable the linting job in CI, to ensure contributions now follow the `.clang-format`.

The benefit to this project is that we can have a consistent and clear formatting style, saving time for developers and reviewers by avoiding having to think/argue about formatting - it can simply be applied with a standard tool.