### PR TITLE
remove OpenSSL requirement for testing

### DIFF
--- a/gloo/test/CMakeLists.txt
+++ b/gloo/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(OpenSSL 1.1.1 REQUIRED EXACT)
+find_package(OpenSSL 1.1.1 EXACT)
 
 set(GLOO_TEST_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/allgather_test.cc"
@@ -13,7 +13,6 @@ set(GLOO_TEST_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/gatherv_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/main.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/memory_test.cc"
-  "${CMAKE_CURRENT_SOURCE_DIR}/openssl_utils.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/reduce_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/send_recv_test.cc"
   )
@@ -29,8 +28,16 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   list(APPEND GLOO_TEST_LIBRARIES rt)
 endif()
 
+if(${OpenSSL_FOUND})
+  list(APPEND GLOO_TEST_SRCS
+  "${CMAKE_CURRENT_SOURCE_DIR}/openssl_utils.cc"
+  )
+  list(APPEND GLOO_TEST_LIBRARIES OpenSSL::SSL OpenSSL::Crypto)
+endif()
+
+
 add_executable(gloo_test ${GLOO_TEST_SRCS})
-target_link_libraries(gloo_test gloo gtest ${GLOO_TEST_LIBRARIES} OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(gloo_test gloo gtest ${GLOO_TEST_LIBRARIES})
 
 if(MSVC AND USE_LIBUV)
   add_custom_command(TARGET gloo_test POST_BUILD


### PR DESCRIPTION
Enable building of gloo_test without requiring OpenSSL to be present. If OpenSSL is not present, SSL/TLS related tests are not linked. If OpenSSL is present, then TLS tests are compiled and linked.