### PR TITLE
Add cstdint header

### DIFF
--- a/gloo/types.h
+++ b/gloo/types.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <iostream>
+#include <cstdint>
 
 #ifdef __CUDA_ARCH__
 #include <cuda.h>


### PR DESCRIPTION
Solves FAILED: third_party/gloo/gloo/CMakeFiles/gloo.dir/types.cc.o  /usr/bin/c++  -I/home/sumantro/pytorch/third_party/gloo -I/home/sumantro/pytorch/build/third_party/gloo -isystem /home/sumantro/pytorch/cmake/../third_party/tensorpipe/third_party/libuv/include -isystem /home/sumantro/pytorch/cmake/../third_party/googletest/googlemock/include -isystem /home/sumantro/pytorch/cmake/../third_party/googletest/googletest/include -isystem /home/sumantro/pytorch/third_party/protobuf/src -isystem /home/sumantro/pytorch/third_party/XNNPACK/include -isystem /home/sumantro/pytorch/third_party/ittapi/include -isystem /home/sumantro/pytorch/cmake/../third_party/eigen -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -std=c++17 -fPIC -O3 -DNDEBUG -std=gnu++17 -DTORCH_USE_LIBUV -MD -MT third_party/gloo/gloo/CMakeFiles/gloo.dir/types.cc.o -MF third_party/gloo/gloo/CMakeFiles/gloo.dir/types.cc.o.d -o third_party/gloo/gloo/CMakeFiles/gloo.dir/types.cc.o -c /home/sumantro/pytorch/third_party/gloo/gloo/types.cc In file included from /home/sumantro/pytorch/third_party/gloo/gloo/types.cc:9: /home/sumantro/pytorch/third_party/gloo/gloo/types.h:66:11: error: ‘uint8_t’ does not name a type
   66 | constexpr uint8_t kGatherSlotPrefix = 0x01;
      |           ^~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:31:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   30 | #include "gloo/common/common.h"
  +++ |+#include <cstdint>
   31 | 
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:67:11: error: ‘uint8_t’ does not name a type
   67 | constexpr uint8_t kAllgatherSlotPrefix = 0x02;
      |           ^~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:67:11: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:68:11: error: ‘uint8_t’ does not name a type
   68 | constexpr uint8_t kReduceSlotPrefix = 0x03;
      |           ^~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:68:11: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:69:11: error: ‘uint8_t’ does not name a type
   69 | constexpr uint8_t kAllreduceSlotPrefix = 0x04;
      |           ^~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:69:11: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:70:11: error: ‘uint8_t’ does not name a type
   70 | constexpr uint8_t kScatterSlotPrefix = 0x05;
      |           ^~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:70:11: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:71:11: error: ‘uint8_t’ does not name a type
   71 | constexpr uint8_t kBroadcastSlotPrefix = 0x06;
      |           ^~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:71:11: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:72:11: error: ‘uint8_t’ does not name a type
   72 | constexpr uint8_t kBarrierSlotPrefix = 0x07;
      |           ^~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:72:11: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:73:11: error: ‘uint8_t’ does not name a type
   73 | constexpr uint8_t kAlltoallSlotPrefix = 0x08;
      |           ^~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:73:11: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:77:21: error: ‘uint8_t’ has not been declared
   77 |   static Slot build(uint8_t prefix, uint32_t tag);
      |                     ^~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:77:21: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:77:37: error: ‘uint32_t’ has not been declared
   77 |   static Slot build(uint8_t prefix, uint32_t tag);
      |                                     ^~~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:77:37: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:79:12: error: expected type-specifier before ‘uint64_t’
   79 |   operator uint64_t() const {
      |            ^~~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:83:18: error: ‘uint8_t’ has not been declared
   83 |   Slot operator+(uint8_t i) const;
      |                  ^~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:83:18: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:86:25: error: expected ‘)’ before ‘base’
   86 |   explicit Slot(uint64_t base, uint64_t delta) : base_(base), delta_(delta) {}
      |                ~        ^~~~~
      |                         )
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:88:9: error: ‘uint64_t’ does not name a type
   88 |   const uint64_t base_;
      |         ^~~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:88:9: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:89:9: error: ‘uint64_t’ does not name a type
   89 |   const uint64_t delta_;
      |         ^~~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:89:9: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:97:3: error: ‘uint16_t’ does not name a type
   97 |   uint16_t x;
      |   ^~~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:97:3: note: ‘uint16_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In constructor ‘gloo::float16::float16()’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:99:15: error: class ‘gloo::float16’ does not have any field named ‘x’
   99 |   float16() : x(0) {}
      |               ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In constructor ‘gloo::float16::float16(int)’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:105:5: error: ‘x’ was not declared in this scope
  105 |     x = res.x;
      |     ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:105:13: error: ‘struct gloo::float16’ has no member named ‘x’
  105 |     x = res.x;
      |             ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In constructor ‘gloo::float16::float16(long unsigned int)’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:110:5: error: ‘x’ was not declared in this scope
  110 |     x = res.x;
      |     ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:110:13: error: ‘struct gloo::float16’ has no member named ‘x’
  110 |     x = res.x;
      |             ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In constructor ‘gloo::float16::float16(long long unsigned int)’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:115:5: error: ‘x’ was not declared in this scope
  115 |     x = res.x;
      |     ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:115:13: error: ‘struct gloo::float16’ has no member named ‘x’
  115 |     x = res.x;
      |             ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In constructor ‘gloo::float16::float16(double)’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:120:5: error: ‘x’ was not declared in this scope
  120 |     x = res.x;
      |     ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:120:13: error: ‘struct gloo::float16’ has no member named ‘x’
  120 |     x = res.x;
      |             ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In member function ‘gloo::float16& gloo::float16::operator=(const int&)’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:125:5: error: ‘x’ was not declared in this scope
  125 |     x = res.x;
      |     ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:125:13: error: ‘struct gloo::float16’ has no member named ‘x’
  125 |     x = res.x;
      |             ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In member function ‘gloo::float16& gloo::float16::operator=(const gloo::float16&)’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:131:7: error: ‘x’ was not declared in this scope
  131 |       x = rhs.x;
      |       ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:131:15: error: ‘const struct gloo::float16’ has no member named ‘x’
  131 |       x = rhs.x;
      |               ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In member function ‘bool gloo::float16::operator==(const gloo::float16&) const’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:137:12: error: ‘x’ was not declared in this scope
  137 |     return x == rhs.x;
      |            ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:137:21: error: ‘const struct gloo::float16’ has no member named ‘x’
  137 |     return x == rhs.x;
      |                     ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In member function ‘bool gloo::float16::operator!=(const gloo::float16&) const’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:141:27: error: ‘const struct gloo::float16’ has no member named ‘x’
  141 |     return !(*this == rhs.x);
      |                           ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In member function ‘bool gloo::float16::operator==(const int&) const’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:146:12: error: ‘x’ was not declared in this scope
  146 |     return x == res.x;
      |            ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:146:21: error: ‘struct gloo::float16’ has no member named ‘x’
  146 |     return x == res.x;
      |                     ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In member function ‘bool gloo::float16::operator==(const long unsigned int&) const’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:151:12: error: ‘x’ was not declared in this scope
  151 |     return x == res.x;
      |            ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:151:21: error: ‘struct gloo::float16’ has no member named ‘x’
  151 |     return x == res.x;
      |                     ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In member function ‘bool gloo::float16::operator==(const double&) const’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:156:12: error: ‘x’ was not declared in this scope
  156 |     return x == res.x;
      |            ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:156:21: error: ‘struct gloo::float16’ has no member named ‘x’
  156 |     return x == res.x;
      |                     ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In function ‘gloo::float16 gloo::cpu_float2half_rn(float)’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:265:9: error: ‘struct gloo::float16’ has no member named ‘x’
  265 |     ret.x = 0x7fffU;
      |         ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:273:9: error: ‘struct gloo::float16’ has no member named ‘x’
  273 |     ret.x = sign | 0x7c00U;
      |         ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:277:9: error: ‘struct gloo::float16’ has no member named ‘x’
  277 |     ret.x = (sign | 0x0000);
      |         ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:307:7: error: ‘struct gloo::float16’ has no member named ‘x’
  307 |   ret.x = (sign | (exponent << 10) | mantissa);
      |       ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h: In function ‘float gloo::cpu_half2float(float16)’:
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:313:23: error: ‘struct gloo::float16’ has no member named ‘x’
  313 |   unsigned sign = ((h.x >> 15) & 1);
      |                       ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:314:27: error: ‘struct gloo::float16’ has no member named ‘x’
  314 |   unsigned exponent = ((h.x >> 10) & 0x1f);
      |                           ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:315:27: error: ‘struct gloo::float16’ has no member named ‘x’
  315 |   unsigned mantissa = ((h.x & 0x3ff) << 13);
      |                           ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.cc: At global scope:
/home/sumantro/pytorch/third_party/gloo/gloo/types.cc:16:6: error: ‘gloo::Slot gloo::Slot::build’ is not a static data member of ‘class gloo::Slot’
   16 | Slot Slot::build(uint8_t prefix, uint32_t tag) {
      |      ^~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.cc:16:18: error: ‘uint8_t’ was not declared in this scope
   16 | Slot Slot::build(uint8_t prefix, uint32_t tag) {
      |                  ^~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.cc:10:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
    9 | #include "gloo/types.h"
  +++ |+#include <cstdint>
   10 | 
/home/sumantro/pytorch/third_party/gloo/gloo/types.cc:16:34: error: ‘uint32_t’ was not declared in this scope
   16 | Slot Slot::build(uint8_t prefix, uint32_t tag) {
      |                                  ^~~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.cc:16:34: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/gloo/gloo/types.cc:16:48: error: expected ‘,’ or ‘;’ before ‘{’ token
   16 | Slot Slot::build(uint8_t prefix, uint32_t tag) {
      |                                                ^
/home/sumantro/pytorch/third_party/gloo/gloo/types.cc:22:6: error: declaration of ‘operator+’ as non-function
   22 | Slot Slot::operator+(uint8_t i) const {
      |      ^~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.cc:22:22: error: ‘uint8_t’ was not declared in this scope
   22 | Slot Slot::operator+(uint8_t i) const {
      |                      ^~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.cc:22:22: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
[1555/7527] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx2.dir/src/FbgemmI8DepthwiseAvx2.cc.o
ninja: build stopped: subcommand failed.

When running setup.py develop on local