### PR TITLE
gloo/types.h: include cstdint

### DIFF
--- a/gloo/types.h
+++ b/gloo/types.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 
 #ifdef __CUDA_ARCH__


### PR DESCRIPTION
fixes unknown type name compile errors.

clang-format'ed version of #448