### PR TITLE
gloo/tcp: better error message on collective mismatch

### DIFF
--- a/gloo/transport/tcp/pair.cc
+++ b/gloo/transport/tcp/pair.cc
@@ -453,7 +453,10 @@ ssize_t Pair::prepareRead(
     iov.iov_len = op.preamble.length - offset;
 
     // Bytes read must be in bounds for target buffer
-    GLOO_ENFORCE_LE(op.preamble.length, op.nbytes);
+    GLOO_ENFORCE_LE(
+        op.preamble.length,
+        op.nbytes,
+        "Received data size doesn't match expected size. Is there a distributed collective mismatch in your code?");
     return iov.iov_len;
   }
 


### PR DESCRIPTION
Summary:
Improve error messages in the TCP transport when a collective mismatch occurs. Right now it throws a mysterious error such as:

```
gloo::EnforceNotMet: [enforce fail at fbcode/gloo/transport/tcp/pair.cc:456] op.preamble.length <= op.nbytes. 194478720 vs 4
```

This updates the error message to indicate that it's a size mismatch and likely due to a bug in the user code.

Meta:

User post: gloo::EnforceNotMet: [enforce fail at fbcode/gloo/transport/tcp/pair.cc:456] op.preamble.length <= op.nbytes. 194478720 vs 4

Differential Revision: D78377800


