### PR TITLE
Fix UB in allgather with zero-size output

### DIFF
--- a/gloo/allgather.cc
+++ b/gloo/allgather.cc
@@ -44,6 +44,11 @@ void allgather(AllgatherOptions& opts) {
   const size_t inBytes = out->size / context->size;
   const size_t outBytes = out->size;
 
+  // Short circuit if the output is empty.
+  if (outBytes == 0) {
+    return;
+  }
+
   // If the input buffer is specified, this is NOT an in place operation,
   // and the output buffer needs to be primed with the input.
   if (in != nullptr) {
@@ -53,8 +58,8 @@ void allgather(AllgatherOptions& opts) {
         in->size);
   }
 
-  // Short circuit if there is only a single process or the output is empty.
-  if (context->size == 1 || outBytes == 0) {
+  // Short circuit if there is only a single process.
+  if (context->size == 1) {
     return;
   }
 


### PR DESCRIPTION
Summary:
When the output buffer is empty (outBytes == 0), the input
buffer pointer may be null. The memcpy at line 50 was called
before the early return check, passing a null pointer to
memcpy which is undefined behavior even with size 0. UBSAN
catches this in the Count_0 test cases.

Move the outBytes == 0 early return before the memcpy to
avoid the null pointer. Split the context->size == 1 check
to remain after the memcpy, since single-process still needs
the input-to-output copy.

Differential Revision: D95712700


