### PR TITLE
Fix stale errno in listDir causing spurious ENOMEM crash

### DIFF
--- a/gloo/common/linux.cc
+++ b/gloo/common/linux.cc
@@ -74,6 +74,8 @@ static std::vector<std::string> listDir(const std::string& path) {
       continue;
     }
     result.push_back(dirent->d_name);
+    // Only report errno values set by readdir, not by vector allocation.
+    errno = 0;
   }
   GLOO_ENFORCE(errno == 0, strerror(errno));
   auto rv = closedir(dirp);

--- a/gloo/test/linux_test.cc
+++ b/gloo/test/linux_test.cc
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <errno.h>
+
 #include <functional>
 #include <thread>
 #include <vector>
@@ -43,6 +45,15 @@ TEST_F(LinuxTest, PCIDistance) {
     auto distance = pciDistance(nics[0], gpu);
     ASSERT_GE(distance, 0);
   }
+}
+
+// Verify that listDir (called by pciDevices) tolerates stale errno left by
+// prior allocations. Before the fix, vector::push_back inside the readdir
+// loop could leave errno=ENOMEM from a transient mmap failure, causing
+// GLOO_ENFORCE(errno == 0) to crash after readdir returns NULL at EOF.
+TEST_F(LinuxTest, PciDevicesDoesNotCrashWithStaleErrno) {
+  errno = ENOMEM;
+  ASSERT_NO_THROW(pciDevices(kPCIClassNetwork));
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

`listDir()` in `gloo/common/linux.cc` checks `errno == 0` after the `readdir` loop to detect errors. However, `vector::push_back` inside the loop may internally trigger `malloc` → `mmap`, which can transiently fail and set `errno = ENOMEM` even when the allocation ultimately succeeds via `brk` or retry. Since POSIX specifies that `readdir` does not modify `errno` on EOF, the stale value survives to the `GLOO_ENFORCE` check, causing a spurious crash.

## Impact

We hit this in production after upgrading `transformers` from 4.57.1 to 5.5.4. The new version calls `importlib.metadata.packages_distributions()` at module level during import, increasing syscall volume by ~49% and heap pressure across all workers. When launching SGLang with TP=16 (`mp.set_start_method("spawn")`), 16 workers simultaneously import heavy Python packages and initialize Gloo process groups. The combined memory pressure makes transient `mmap` failures far more likely during the `listDir("/sys/bus/pci/devices/")` call (623 PCI entries on our machines), causing frequent crashes at startup.

Rolling back to transformers 4.57.1 masked the issue (lower heap pressure → fewer transient mmap failures), but the underlying errno handling bug in `listDir` remained.

## Reproduction

Observed on machines with 600+ PCI devices under memory pressure from 16 concurrent process spawns (e.g., PyTorch TP=16 with `mp.spawn`).  Confirmed via `objdump` disassembly (locating `_M_realloc_insert` in the readdir loop) and an LD_PRELOAD probe that caught `errno=12` at readdir EOF after all 623 directory entries were successfully read.

## Fix

Clear `errno` after each `push_back` call so that only `readdir`'s own error state is visible after the loop. This is safe because `push_back` throws `std::bad_alloc` on real allocation failure — a successful return means the stale errno is a false positive.

## Test

Added `PciDevicesDoesNotCrashWithStaleErrno` to `linux_test.cc` which sets `errno = ENOMEM` before calling `pciDevices()` (the public API that invokes `listDir`) and verifies no exception is thrown.
